### PR TITLE
remove several fields that are not really useful

### DIFF
--- a/include/btree.hpp
+++ b/include/btree.hpp
@@ -5,19 +5,13 @@
 #include "../include/file_cache.hpp"
 #include "../include/file_allocator.hpp"
 
-
-
 struct btree_node_info
 {
     far_offset_ptr node_offset;
     uint16_t btree_position;
     uint16_t btree_size;
 
-    std::vector<uint8_t> key;
     bool is_found;
-    bool is_full;
-    bool is_leaf;
-    bool is_root;
 
     bool operator==(const btree_node_info& other) const = default;
 
@@ -107,14 +101,6 @@ public:
             {
                 info.btree_position = read_key_position;
                 info.is_found = true; // In a branch node, we always find the key or the position where it would be inserted
-            }
-
-            // if there's a key, read it
-            if (read_key_position < node.get_entry_count())
-            {
-                auto span = node.get_key_at(read_key_position);
-                info.key.resize(span.size());
-                std::copy(span.begin(), span.end(), info.key.begin());
             }
 
             result.path.push_back(info);

--- a/objectdb/objectdb.cpp
+++ b/objectdb/objectdb.cpp
@@ -10,7 +10,10 @@ void write_path(const btree_iterator& it)
 {
     for (int n = 0; n < it.path.size(); n++)
     {
-        std::cout << it.path[n].node_offset.get_file_id() << "/" << it.path[n].node_offset.get_offset() << " " << it.path[n].btree_position << " - " << (it.path[n].is_found ? "found" : "not found") << std::endl;
+        std::cout << it.path[n].node_offset.get_file_id() << "/" << it.path[n].node_offset.get_offset()
+            << " " << it.path[n].btree_position
+            << " - " << (it.path[n].is_found ? "found" : "not found")
+            << std::endl;
     }
 }
 

--- a/problems.txt
+++ b/problems.txt
@@ -3,5 +3,3 @@
  * btree needs to know if it's writing it's first node
  * on first write, btree needs to know it's size
  * does the btree need to be passed info about where to put it's first node?
-
-


### PR DESCRIPTION
I was thinking about the use of the keys in the nodes, and it's not really useful metadata, and probably makes things a little slower everything but is_found is not all that useful either, and looks to have been set inconsistently